### PR TITLE
Updated for loadash ^4.0.0 support.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -48,7 +48,7 @@ function JunitReporter(emitter, pluginOptions) {
         }
         var results = {
             testsuites: {
-                testsuite: _.map(_.sortBy(_.unique(_.pluck(this.tests, 'suite'))), function (suite) {
+                testsuite: _.map(_.sortBy(_.uniqBy(_.map(this.tests, 'suite'))), function (suite) {
                     var tests = _.filter(this.tests, {
                         suite: suite
                     });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/marcelmeulemans/wct-junit-reporter",
     "dependencies": {
         "pixl-xml": "^1.0.4",
-        "lodash": "^3.10.1",
+        "lodash": "^4.0.0",
         "he": "^0.5.0"
     },
     "wct-plugin": {


### PR DESCRIPTION
As of loadash 4.0.0 `.unique` and `.pluck` are deprecated.  [More on loadash 4.0.0 changelog](https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings)